### PR TITLE
Add support for web_sys in addition to stdweb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,6 @@ features = ["console"]
 wasm-bindgen = { version = "0.2" }
 
 [features]
+default = ["std_web"]
 std_web = ["stdweb"]
 web_sys = ["web-sys"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "web_logger"
+edition = "2018"
 version = "0.2.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 repository = "https://github.com/DenisKolodin/web-logger"
@@ -13,7 +14,20 @@ description = "A logger for logging in web-browsers"
 
 [dependencies]
 log = "0.4"
-stdweb = "0.4"
+cfg-if = "0.1.10"
+
+[dependencies.stdweb]
+version = "0.4"
+optional = true
+
+[dependencies.web-sys]
+version = "0.3"
+optional = true
+features = ["console"]
 
 [target.'cfg(all(target_arch = "wasm32", not(cargo_web)))'.dependencies]
 wasm-bindgen = { version = "0.2" }
+
+[features]
+std_web = ["stdweb"]
+web_sys = ["web-sys"]

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ web_logger = "0.2"
 After it's initialized, you can use the `log` macros to do actual logging.
 
 ```rust
-#[macro_use]
-extern crate log;
-extern crate web_logger;
+use log::info;
 
 fn main() {
     web_logger::init();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,52 +1,32 @@
 //! A logger that prints all messages in browser's console.
 
 extern crate log;
-#[macro_use]
-extern crate stdweb;
 
-use log::{
-    Log,
-    Level,
-    Metadata,
-    Record,
-    SetLoggerError,
-};
+use log::{Level, Log, Metadata, Record, SetLoggerError};
 
-mod console {
-    pub(super) fn trace(message: &str) {
-        js! { @(no_return) console.log(@{message}); }
-    }
-
-    pub(super) fn debug(message: &str) {
-        js! { @(no_return) console.debug(@{message}); }
-    }
-
-    pub(super) fn info(message: &str) {
-        js! { @(no_return) console.info(@{message}); }
-    }
-
-    pub(super) fn warn(message: &str) {
-        js! { @(no_return) console.warn(@{message}); }
-    }
-
-    pub(super) fn error(message: &str) {
-        js! { @(no_return) console.error(@{message}); }
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std_web")] {
+        #[macro_use]
+        extern crate stdweb;
+        mod std_web;
+        use std_web::console;
+    } else if #[cfg(feature = "web_sys")] {
+        mod web_sys;
+        use crate::web_sys::console;
     }
 }
 
-
 pub struct Config {
-    pub level: Level
+    pub level: Level,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Config {
-            level: Level::Trace
+            level: Level::Trace,
         }
     }
 }
-
 
 static LOGGER: WebLogger = WebLogger;
 
@@ -61,10 +41,12 @@ impl Log for WebLogger {
     fn log(&self, record: &Record) {
         let metadata = record.metadata();
         if self.enabled(metadata) {
-            let msg = format!("{}:{} -- {}",
+            let msg = format!(
+                "{}:{} -- {}",
                 record.level(),
                 record.target(),
-                record.args());
+                record.args()
+            );
             match metadata.level() {
                 Level::Trace => console::trace(&msg),
                 Level::Debug => console::debug(&msg),
@@ -75,8 +57,7 @@ impl Log for WebLogger {
         }
     }
 
-    fn flush(&self) {
-    }
+    fn flush(&self) {}
 }
 
 pub fn try_init(config: Config) -> Result<(), SetLoggerError> {
@@ -87,9 +68,11 @@ pub fn try_init(config: Config) -> Result<(), SetLoggerError> {
 }
 
 pub fn init() {
-    try_init(Config::default()).expect("web_logger::init should not be called after logger initialized");
+    try_init(Config::default())
+        .expect("web_logger::init should not be called after logger initialized");
 }
 
 pub fn custom_init(config: Config) {
-    try_init(config).expect("web_logger::custom_init should not be called after logger initialized");
+    try_init(config)
+        .expect("web_logger::custom_init should not be called after logger initialized");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,15 @@
 //! A logger that prints all messages in browser's console.
-
-extern crate log;
+//!
+//! By default, `web_logger` will use the `std_web` feature, which depends on `stdweb`. If you want to use `web-sys`,
+//! add this to your Cargo.toml under `[dependencies]`:
+//! ```toml
+//! web_logger = { version="0.2", default-features=false, features="web_sys" }
+//! ```
 
 use log::{Level, Log, Metadata, Record, SetLoggerError};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "std_web")] {
-        #[macro_use]
-        extern crate stdweb;
         mod std_web;
         use std_web::console;
     } else if #[cfg(feature = "web_sys")] {

--- a/src/std_web.rs
+++ b/src/std_web.rs
@@ -1,0 +1,21 @@
+pub mod console {
+    pub fn trace(message: &str) {
+        js! { @(no_return) console.log(@{message}); }
+    }
+
+    pub fn debug(message: &str) {
+        js! { @(no_return) console.debug(@{message}); }
+    }
+
+    pub fn info(message: &str) {
+        js! { @(no_return) console.info(@{message}); }
+    }
+
+    pub fn warn(message: &str) {
+        js! { @(no_return) console.warn(@{message}); }
+    }
+
+    pub fn error(message: &str) {
+        js! { @(no_return) console.error(@{message}); }
+    }
+}

--- a/src/std_web.rs
+++ b/src/std_web.rs
@@ -1,4 +1,6 @@
-pub mod console {
+pub(super) mod console {
+    use stdweb::js;
+
     pub fn trace(message: &str) {
         js! { @(no_return) console.log(@{message}); }
     }

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1,4 +1,4 @@
-pub mod console {
+pub(super) mod console {
     use web_sys::console;
 
     pub fn trace(message: &str) {

--- a/src/web_sys.rs
+++ b/src/web_sys.rs
@@ -1,0 +1,23 @@
+pub mod console {
+    use web_sys::console;
+
+    pub fn trace(message: &str) {
+        console::log_1(&message.into());
+    }
+
+    pub fn debug(message: &str) {
+        console::debug_1(&message.into());
+    }
+
+    pub fn info(message: &str) {
+        console::info_1(&message.into());
+    }
+
+    pub fn warn(message: &str) {
+        console::warn_1(&message.into());
+    }
+
+    pub fn error(message: &str) {
+        console::error_1(&message.into());
+    }
+}


### PR DESCRIPTION
This crate depended on `stdweb`, which is not desirable if you prefer to use `web-sys`, like the main Yew project is moving to.

Many of the examples in the Yew project depend on `web_logger`, and therefore implicitly pull in `stdweb` even though they're supposed to be `web-sys` only. I assume they will benefit from smaller code size once `web_logger` can use `web-sys` as well.

- Updated to Rust 2018 edition (no `extern crate` or `macro_use`)
- Use a stdweb- or web-sys-based module based on the selected feature
- `std_web` as default feature to keep backward compatibility

Some diffs are entirely `cargo fmt`s doing.

## Questions

I'm not confident that I applied `pub(super)` right in the respective modules, but I tried to mirror the original.

I think it would be nice to provide a warning if someone were to try to install both features (which could happen if they forgot `default-features = false`). Not sure how to do that. Because of the order of `cfg_if`, this would build the `std_web` module.